### PR TITLE
Fix docs link for arts and crafts

### DIFF
--- a/index.html
+++ b/index.html
@@ -172,7 +172,7 @@
                          <li class="text-center text-muted">You will play mahjong in this tournament, not just make art you baka! - TO </li>
                          <li>
                            <ul>
-                             <li><a href="https://docs.google.com/document/d/1Z-_YJ7BnFS_HG6VUGDmAciyy3NfrVNrHXJTPNfRpQYY/edit" title="">Docs</a></li>
+                             <li><a href="https://docs.google.com/document/d/13XNMv8HL3mzBZD7nZZKYe-3Aix78BIQJQuNa1C3HHUk/edit?usp=sharing" title="">Docs</a></li>
                              <li><a href="https://forms.gle/mGHb4MZ3mpDkMcdk8" title="">SIGN UP</a></li>
 
                            </ul>


### PR DESCRIPTION
google docs pointed to announcement doc; replaced with full doc link.