### PR TITLE
Add post anchors, fix back button when navigating reply chains.

### DIFF
--- a/404.html
+++ b/404.html
@@ -369,6 +369,7 @@
 			container.find('.header .date').text(new Date(data.postTime).toLocaleString())
 			container.find('.header .link').attr('href', data.postNumber)
 			container.find('.header .link').attr('id', data.postNumber)
+			container.find('.header .link').attr('name', `p${data.postNumber}`)
 			container.find('.header .numbers').text(data.postNumber).on('click', (e) => {
 				if (!getThreadId()) {
 					window.location = '/' + data.postNumber
@@ -526,6 +527,7 @@
 		function scrollToPost(postNumber) {
 			const post = document.querySelectorAll(`[data-post="${postNumber}"]`)[0]
 			if (post) {
+				history.pushState(`#p${postNumber}`, "")
 				post.scrollIntoView({ behavior: "smooth" })
 				return true
 			}


### PR DESCRIPTION
 * Change `scrollToPost` to save the current scroll position with `history.pushState`, so pressing the back button will return you to the previous position.
 * Add `p123` anchors to posts which aren't needed for history tracking, but satisfies my autism. 4chan puts the anchor on "No." which acts as a self-link but I can't be bothered to update the template.