### PR TITLE
Exclude thread template when appending to thread

### DIFF
--- a/404.html
+++ b/404.html
@@ -807,7 +807,7 @@
 				.then(body => body.json())
 				.then(data => {
 					data.posts.forEach((post) => {
-						renderPost(post).appendTo($('.thread'))
+						renderPost(post).appendTo($('.thread:not(.template)'))
 					})
 					updateCount(data.thread.replies, data.thread.totalReplies)
 					return {


### PR DESCRIPTION
Exclude thread template when appending to thread, should fix issues with scrolling to elements added by updates.