### PR TITLE
Update mjg Emote Replacer.user.js to support multilingual emotes and add links to updates.json/index.html essentials section as suggested by an Anon

### DIFF
--- a/index.html
+++ b/index.html
@@ -557,6 +557,7 @@
               <li><a href="https://mjg.booru.org/">/mjg/ Booru</a></li>
               <li><a href="https://files.riichi.moe/mjg/game%20resources%20and%20tools/Hime%20Mahjong/emotes/">Hime
                   Emotes</a></li>
+              <li><a href="/others/userscripts/4chan/mjg%20Emote%20Replacer.user.js">/mjg/ Emote Replacer</a></li>
             </ul>
           </td>
         </tr>

--- a/others/userscripts/4chan/mjg Emote Replacer.user.js
+++ b/others/userscripts/4chan/mjg Emote Replacer.user.js
@@ -7,7 +7,7 @@
 // @author       Ling and Anon
 // @match        *://boards.4chan.org/vg/thread/*
 // @grant        none
-// @downloadURL  https://github.com/vg-mjg/mjg-repo/raw/refs/heads/master/others/userscripts/4chan/mjg%20Emote%20Replacer.user.js
+// @downloadURL  https://repo.riichi.moe/others/userscripts/4chan/mjg%20Emote%20Replacer.user.js
 // @run-at       document-idle
 // @license      MIT
 // ==/UserScript==

--- a/others/userscripts/4chan/mjg Emote Replacer.user.js
+++ b/others/userscripts/4chan/mjg Emote Replacer.user.js
@@ -1,12 +1,13 @@
 // ==UserScript==
 // @name         /mjg/ Emote Replacer
 // @namespace    http://repo.riichi.moe/
-// @version      1.3.3
+// @version      1.3.4
 // @description  Detects emote strings in imageless posts after the image limit is reached in /mjg/ threads, and displays them as fake images posts.
 // @icon         https://files.catbox.moe/3sh459.png
 // @author       Ling and Anon
 // @match        *://boards.4chan.org/vg/thread/*
 // @grant        none
+// @downloadURL  https://github.com/vg-mjg/mjg-repo/raw/refs/heads/master/others/userscripts/4chan/mjg%20Emote%20Replacer.user.js
 // @run-at       document-idle
 // @license      MIT
 // ==/UserScript==
@@ -16,7 +17,7 @@
 
     const IMAGE_LIMIT = 375; // Change this to 0 if you want the script to work even if the thread hasn't hit the image limit
     const EMOTE_BASE_URL = 'https://files.riichi.moe/mjg/game%20resources%20and%20tools/Mahjong%20Soul/game%20files/emotes/';
-    const EMOTE_REGEX = /\b([a-zA-Z0-9\-\.]+-\d+\.(?:png|jpg|jpeg|gif))\b/i;
+    const EMOTE_REGEX = /\b([a-zA-Z0-9\-\.]+-\d+[cehjk]?t?d?\.(?:png|jpg|jpeg|gif))\b/i;
     const PROCESSED_MARKER = 'data-mjg-emote-processed'; // Values: 'true' (success), 'has-file', 'no-message', 'limit-not-reached', 'emote-not-found', 'checking'
 
     // --- Helper: Check if remote image exists ---

--- a/others/userscripts/4chan/mjg Tiler.user.js
+++ b/others/userscripts/4chan/mjg Tiler.user.js
@@ -2,8 +2,8 @@
 // @name         /mjg/ Tiler
 // @namespace    http://repo.riichi.moe/
 // @icon         https://files.catbox.moe/iz2zh3.png
-// @version      1.2.3
-// @description  Highlights tile notation. Hover over text to view image. Double click to freeze the image for saving and whatnot.
+// @version      1.2.4
+// @description  Highlights tile notation. Hover over text to view image.
 // @author       anon
 // @match        *://boards.4chan.org/*/thread/*
 // @run-at       document-start
@@ -19,26 +19,25 @@ const scale = 0.375;
 GM_addStyle(`
 .mjgTilemaker{
   position: relative;
-  display: run-in;
+  display: inline-block;
   border-bottom: 1px dotted black;
 }
-
+ 
 .mjgTilemakerBox{
-  visibility: visible;
+  visibility: hidden;
   text-align: center;
-  overflow: hidden;
+  overflow: visible;
   border-radius: 3px;
-
-  position: relative;
-  transform: translate(0, 0);
-  padding: 0px;
-  bottom: 0;
-  left: 0;
-
-  opacity: 1;
+ 
+  position: absolute;
+  transform: translate(-50%, 0);
+  bottom: 125%;
+  left: 50%;
+ 
+  opacity: 0;
   transition: opacity 0.3s;
 }
-
+ 
 .mjgTilemaker:hover .mjgTilemakerBox {
   visibility: visible;
   opacity: 1;
@@ -76,7 +75,7 @@ var atlas_img;
                         } else {
                             let newElement = document.createElement("span");
                             let tileBox = document.createElement("span");
-                            //newElement.innerHTML = result;
+                            newElement.innerHTML = result;
                             newElement.className = "mjgTilemaker";
                             newElement.ondblclick = () => {
                                 let tileBox = document.getElementById('mjgTilebox'+post.id);

--- a/updates.json
+++ b/updates.json
@@ -7,6 +7,12 @@
   },
   "updates": [
     {
+      "title": "/mjg/ userscripts and userstyles",
+      "link": "https://repo.riichi.moe/library.html#resources-mjg",
+      "category": "/mjg/ project",
+      "description": "Uploaded some userscripts (emote replacer) and a userstyle (4han theme) that were contributed by various Anons."
+    },
+    {
       "title": "4han.moe",
       "link": "https://4han.moe/",
       "category": "/mjg/ project",

--- a/updates.json
+++ b/updates.json
@@ -10,7 +10,7 @@
       "title": "/mjg/ userscripts and userstyles",
       "link": "https://repo.riichi.moe/library.html#resources-mjg",
       "category": "/mjg/ project",
-      "description": "Uploaded some userscripts (emote replacer) and a userstyle (4han theme) that were contributed by various Anons."
+      "description": "Uploaded some userscripts (emote replacer for /vg/ and FC2) and a userstyle (4han theme) that were contributed by various Anons."
     },
     {
       "title": "4han.moe",


### PR DESCRIPTION
Update to v1.3.4 of the emote replacer userscript:
- Added downloadURL clause to enable autoupdating the script (shouldn't be necessary for people who have already installed it from the repo)
- Changed the emote string detection regex to support emote variations in other languages (thanks >>>/vg/523413521).

Update updates.json and index.html to link to the userscripts (thanks >>>/vg/523201270).
Revert the way the /mjg/ tiler userscript works to the original version as suggested by >>>/vg/523201681