### PR TITLE
adding updates for 2x books

### DIFF
--- a/updates.json
+++ b/updates.json
@@ -7,6 +7,18 @@
   },
   "updates": [
     {
+      "title": "Double Your Safe Tiles! Mahjong Discard Reading Drills - Hirasawa Genki",
+      "link": "https://files.riichi.moe/mjg/books%20(en)/Double%20Your%20Safe%20Tiles%21%20Mahjong%20Discard%20Reading%20Drills%20-%20Hirasawa%20Genki.pdf",
+      "category": "Books",
+      "description": "A comprehensive course on reading and responding to open hands. Detailed explanations accompany 80 3D WWYDs which highlight using calls and discards to deduce opponent yaku, value, progress, and likely waits."
+    },
+    {
+      "title": "Frequently Appearing in Actual Games! Mahjong Lectures - Yuusei",
+      "link": "https://files.riichi.moe/pr/books%20(en)/Mahjong%20Lectures%20-%20Yuusei.pdf",
+      "category": "Books",
+      "description": "Various lectures on hand-building, adjusting play based on the point distribution, push-fold, and reading discards to infer hand development, blocks, and probable waits."
+    },
+    {
       "title": "Majsoul emotes (Update 2025-06-25)",
       "link": "https://files.riichi.moe/mjg/game%20resources%20and%20tools/Mahjong%20Soul/game%20files/emotes/?zip=utf8",
       "category": "Resource",

--- a/updates.json
+++ b/updates.json
@@ -8,7 +8,7 @@
   "updates": [
     {
       "title": "Double Your Safe Tiles! Mahjong Discard Reading Drills - Hirasawa Genki",
-      "link": "https://files.riichi.moe/mjg/books%20(en)/Double%20Your%20Safe%20Tiles%21%20Mahjong%20Discard%20Reading%20Drills%20-%20Hirasawa%20Genki.pdf",
+      "link": "https://files.riichi.moe/pr/books%20(en)/Double%20Your%20Safe%20Tiles%21%20Mahjong%20Discard%20Reading%20Drills%20-%20Hirasawa%20Genki.pdf",
       "category": "Books",
       "description": "A comprehensive course on reading and responding to open hands. Detailed explanations accompany 80 3D WWYDs which highlight using calls and discards to deduce opponent yaku, value, progress, and likely waits."
     },


### PR DESCRIPTION
Please move the 2x TLs from /pr/ (en books) to /mjg/
the links in this pr should be redirected to /mjg/
the needed changes to resources-strategy have been made (currently dead linking to /mjg/)